### PR TITLE
adjust toggleswitch enable indicator position

### DIFF
--- a/Styling-Qt-Widgets/toggleswitch.cpp
+++ b/Styling-Qt-Widgets/toggleswitch.cpp
@@ -83,7 +83,7 @@ void ToggleSwitch::paintEvent(QPaintEvent *)
     valueRect.setWidth(valueRect.height()); // must be a square
 
     if (m_checked) {
-        valueRect.moveLeft(width() / 2);
+        valueRect.moveLeft(width() - valueRect.width() - s_innerMargin);
         painter.setPen(QPen(ColorRepository::progressBarOutlineBrush(valueRect), 1));
         painter.setBrush(Qt::NoBrush);
     } else {


### PR DESCRIPTION
when toggleswitch expand with horizontal direction, toggleswitch indicator position is unmatch.
