### PR TITLE
Add an explanation page to qfontmetrics

### DIFF
--- a/Qt-Widgets-and-more/font-metrics/Example.cpp
+++ b/Qt-Widgets-and-more/font-metrics/Example.cpp
@@ -179,6 +179,18 @@ void Example::draw(QPainter *painter, Mode mode)
         drawPoint(painter, -boundingRect.topLeft(), Qt::blue);
         break;
     }
+    case Explanation: {
+        QPoint pos{0, 0};
+        painter->setPen(Qt::black);
+        painter->drawText(pos, text);
+        drawPoint(painter, pos, Qt::blue);
+        painter->setPen(QPen(Qt::green, 3.0 / SCALE, Qt::SolidLine));
+        rect = fm.boundingRect(text);
+        rect.translate(pos);
+        painter->drawRect(rect);
+        painter->setPen(Qt::black);
+        break;
+    }
     }
 }
 
@@ -238,6 +250,22 @@ void Example::nextStep(int delta)
         break;
     case UsingPointAPITight:
         setTitle("Finally let's check if it also works with tightBoundingRect()");
+        break;
+    case Explanation:
+        setTitle("Explanation: Text is drawn around the baseline and the horizontal advance. "
+                 "A character can have a leftBearing(), which might be negative like the italic "
+                 "f and j extending into the previous character. Likewise for the right, but "
+                 "possibly extending into the next one. Since in the vertical direction 0 is "
+                 "the baseline, the top is at -ascend() and the bottom at descend().\n"
+                 "\n"
+                 "Hence the boundingRect is always negative in the y-direction and can be in the "
+                 "x-direction. That is not a point and a size as suggested on youtube, it _is_ the "
+                 "bounding rect, but around the _point_ the text is drawn at and not the rectangle "
+                 "the text is drawn _in_ as the helper qpainter->drawText(rect) does.\n"
+                 "\n"
+                 "It can be easily demonstrated by drawing the text at 0,0 and "
+                 "drawing the boundingRect() as shown below."
+                 );
         break;
     }
     update();

--- a/Qt-Widgets-and-more/font-metrics/Example.h
+++ b/Qt-Widgets-and-more/font-metrics/Example.h
@@ -30,7 +30,8 @@ private:
         TightBoundaryBox,
         UsingPointAPI,
         UsingPointAPITight,
-        NumberOfModes = UsingPointAPITight,
+        Explanation,
+        NumberOfModes = Explanation,
     };
     void draw(QPainter *painter, Mode);
     void nextStep(int delta);


### PR DESCRIPTION
I found below video on YouTube, which was asking for comments, so here we go.
Hopefully that makes it a bit less confusing.

On YouTube [1] it is suggested that it explains how QFontMetrics works, but that deserves a bit better explanation (the rain thing is actually wrong). So lets add an explanation page. Text is not positioned at the top, left corner and that is an important thing to know, so lets add and explanation.

[1] https://www.youtube.com/watch?v=v8dVSxkHgV0